### PR TITLE
Stop autosave to always refresh the preview on any content change

### DIFF
--- a/design/admin/templates/content/edit/autosave.tpl
+++ b/design/admin/templates/content/edit/autosave.tpl
@@ -117,7 +117,7 @@ YUI(YUI3_config).use('ezautosubmit', 'ezcontentpreview', 'node-base', 'node-styl
              .addClass('as-success')
              .setContent(e.json.content.message_success + ' ' + msgAgo)
              .setAttribute('title', '');
-        if( !preview.collapsible.conf.collapsed ) {
+        if ( !preview.collapsible.conf.collapsed ) {
             preview.setContent( e.json.content.preview );
         }
         if ( timer ) {

--- a/design/admin/templates/content/edit/autosave.tpl
+++ b/design/admin/templates/content/edit/autosave.tpl
@@ -117,7 +117,9 @@ YUI(YUI3_config).use('ezautosubmit', 'ezcontentpreview', 'node-base', 'node-styl
              .addClass('as-success')
              .setContent(e.json.content.message_success + ' ' + msgAgo)
              .setAttribute('title', '');
-        preview.setContent(e.json.content.preview);
+        if( !preview.collapsible.conf.collapsed ) {
+            preview.setContent( e.json.content.preview );
+        }
         if ( timer ) {
             timer.cancel();
         }

--- a/design/admin/templates/content/edit/autosave.tpl
+++ b/design/admin/templates/content/edit/autosave.tpl
@@ -118,7 +118,7 @@ YUI(YUI3_config).use('ezautosubmit', 'ezcontentpreview', 'node-base', 'node-styl
              .setContent(e.json.content.message_success + ' ' + msgAgo)
              .setAttribute('title', '');
         if ( !preview.collapsible.conf.collapsed ) {
-            preview.setContent( e.json.content.preview );
+            preview.setContent(e.json.content.preview);
         }
         if ( timer ) {
             timer.cancel();


### PR DESCRIPTION
The autosave functionality is updating the preview (requesting the preview in an HTML iframe tag) on any content change. Even when the preview is not visible.

This pull request will change the behaviour and only update the preview iframe when it is actually visible (use opens the popup window).